### PR TITLE
fix: remove initial cooldown

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -106,10 +106,18 @@
   async function handleRateLimiting(lastPressedDateInSeconds = null) {
     const currentTimeInSeconds = getCurrentTimeInSeconds();
 
-    if (lastPressedDateInSeconds)
+    if (lastPressedDateInSeconds) {
       saveData(lastPressedDateKey, lastPressedDateInSeconds);
-    else
+    } else {
       lastPressedDateInSeconds = await getSavedDate();
+    }
+    
+
+    // If there's no saved data, that means the user is opening the extension for the first time ever.
+    // In this case, don't rate limit this first request for friend IDs.
+    if (lastPressedDateInSeconds === null) {
+      return;
+    }
 
     const secondsSinceLastPressed = currentTimeInSeconds - lastPressedDateInSeconds;
 
@@ -215,14 +223,16 @@
 
   /**
    * Gets the last pressed date from Chrome storage.
-   * @returns {Promise<int>} The date in seconds.
+   *
+   * @returns {Promise<number | null>} 
+   * Returns the date in seconds of the last time the friend IDs were fetched.
+   * Returns null if no date saved in storage (ie.e the extension has not be used yet).
    */
   async function getSavedDate() {
     const dateInStorage = (await getData())[lastPressedDateKey];
     if (dateInStorage) return dateInStorage;
-    const currentTime = getCurrentTimeInSeconds();
-    saveData(lastPressedDateKey, currentTime);
-    return currentTime;
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
## What I Did

I removed the 60 second timeout for the first request, if the user is using the extension for the first time ever.

## Bug Description

The extension was making you sit there for 60 seconds after installing before you could get friend ids.

## Steps to Reproduce

1. Remove the chrome extension if you have it (this is to clear out the chrome storage)
2. Add the chrome extension back:  [https://chrome.google.com/webstore/detail/vrchat-friend-ids/gaojhlfhffchkcpbfchmpdhcljhafpnn](https://chrome.google.com/webstore/detail/vrchat-friend-ids/gaojhlfhffchkcpbfchmpdhcljhafpnn)
3. Open the extension by clicking the F.Y.N.N. icon

### Expected Results

You can click the Get IDs button

### Actual Results

You have to wait 60 seconds, even though you haven’t hit the API yet

## How to Test This Fix

1. Clone this repo and check out this branch
2. Go to chrome://extensions
3. Click "Load unpacked" and select the directory you cloned the repo into
4. Click the plugin icon in your chrome address bar (looks like a puzzle piece)
5. You should see the popup and the "Get IDs" button is enabled.

![image](https://user-images.githubusercontent.com/700323/169956507-0bf66a22-89ea-4426-b4a8-954d4954ee06.png)

6. Note that you do not have to wait 60 seconds to use the extension
7. Make sure you are logged into VRchat
8. Click the Get IDs button
9. Note that you get friend IDs and then the button goes on a 60 cooldown as expected.
![image](https://user-images.githubusercontent.com/700323/169956591-aef31feb-65e4-45a8-99dd-72dab63a92de.png)
